### PR TITLE
Feature: optional inline block titles

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.info.yml
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.info.yml
@@ -1,0 +1,8 @@
+name: "Layout Builder Custom"
+description: Customizations to make Layout Builder more usable.
+type: module
+core: 8.x
+package: Custom - UIowa
+dependencies:
+  - drupal:layout_builder
+  - drupal:block

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains lb_enhancements.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'layout_builder_add_block') {
+    $form['settings']['label']['#required'] = FALSE;
+
+    $form['settings']['label_display']['#default_value'] = FALSE;
+  }
+}

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -13,7 +13,31 @@ use Drupal\Core\Form\FormStateInterface;
 function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form_id == 'layout_builder_add_block') {
     $form['settings']['label']['#required'] = FALSE;
-
     $form['settings']['label_display']['#default_value'] = FALSE;
+
+    $label = $form['settings']['label'];
+    $label_display = $form['settings']['label_display'];
+
+    unset($form['settings']['label']);
+    unset($form['settings']['label_display']);
+
+    $label += [
+      '#attributes' => ['name' => 'inline_block_label'],
+      '#states' => [
+        'visible' => [
+          ':input[name="inline_block_label_display"]' => [
+            'checked' => TRUE,
+          ],
+        ],
+      ],
+    ];
+
+    $label_display += [
+      '#attributes' => [
+        'name' => 'inline_block_label_display'
+      ],
+    ];
+
+    $form['settings'] += ['label_display' => $label_display, 'label' => $label];
   }
 }

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -34,10 +34,13 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
 
     $label_display += [
       '#attributes' => [
-        'name' => 'inline_block_label_display'
+        'name' => 'inline_block_label_display',
       ],
     ];
 
-    $form['settings'] += ['label_display' => $label_display, 'label' => $label];
+    $form['settings'] += [
+      'label_display' => $label_display,
+      'label' => $label,
+    ];
   }
 }

--- a/docroot/profiles/custom/collegiate_basic/collegiate_basic.info.yml
+++ b/docroot/profiles/custom/collegiate_basic/collegiate_basic.info.yml
@@ -22,6 +22,7 @@ install:
   - help
   - image
   - layout_builder
+  - layout_builder_custom
   - layout_builder_restrictions
   - layout_builder_styles
   - lightning_media_bulk_upload


### PR DESCRIPTION
This feature does the following:
* Makes the title in the inline block form optional
* Moves the title field and title display checkbox to the end of the block settings
* Shows the title field if the title display checkbox is checked and hides it otherwise