### PR TITLE
Feature: Enhancements for uiowa_lb_blocks 

### DIFF
--- a/docroot/modules/custom/uiowa_lb_blocks/config/install/config_snapshot.snapshot.config_sync.module.uiowa_lb_blocks.yml
+++ b/docroot/modules/custom/uiowa_lb_blocks/config/install/config_snapshot.snapshot.config_sync.module.uiowa_lb_blocks.yml
@@ -542,6 +542,2039 @@ items:
                                     description: ''
                                 -
                                   collection: ''
+                                  name: config_snapshot.snapshot.config_sync.module.uiowa_lb_blocks
+                                  data:
+                                    langcode: en
+                                    status: true
+                                    dependencies:
+                                      module:
+                                        - uiowa_lb_blocks
+                                    id: config_sync.module.uiowa_lb_blocks
+                                    snapshotSet: config_sync
+                                    extensionType: module
+                                    extensionName: uiowa_lb_blocks
+                                    items:
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_banner
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_banner
+                                          label: 'UIowa Banner'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_card
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_card
+                                          label: 'UIowa Card'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_feature
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_feature
+                                          label: 'UIowa Feature'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_noteworthy
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_spacer_separator
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_spacer_separator
+                                          label: 'UIowa Spacer/Separator'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_statistic
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_statistic
+                                          label: 'UIowa Statistic'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: block_content.type.uiowa_text_area
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: uiowa_text_area
+                                          label: 'UIowa Text Area'
+                                          revision: 1
+                                          description: ''
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_banner.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_image
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_link
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_title
+                                              - image.style.thumbnail
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_banner.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_banner
+                                          mode: default
+                                          content:
+                                            field_uiowa_banner_excerpt:
+                                              weight: 27
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textarea
+                                              region: content
+                                            field_uiowa_banner_image:
+                                              type: image_image
+                                              weight: 29
+                                              settings:
+                                                preview_image_style: thumbnail
+                                                progress_indicator: throbber
+                                              region: content
+                                              third_party_settings: {  }
+                                            field_uiowa_banner_link:
+                                              weight: 28
+                                              settings:
+                                                placeholder_url: ''
+                                                placeholder_title: ''
+                                              third_party_settings: {  }
+                                              type: link_default
+                                              region: content
+                                            field_uiowa_banner_title:
+                                              weight: 26
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_card.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_excerpt
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_image
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_link
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_title
+                                              - image.style.thumbnail
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_card.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_card
+                                          mode: default
+                                          content:
+                                            field_uiowa_card_excerpt:
+                                              weight: 27
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textarea
+                                              region: content
+                                            field_uiowa_card_image:
+                                              type: image_image
+                                              weight: 29
+                                              settings:
+                                                preview_image_style: thumbnail
+                                                progress_indicator: throbber
+                                              region: content
+                                              third_party_settings: {  }
+                                            field_uiowa_card_link:
+                                              weight: 28
+                                              settings:
+                                                placeholder_url: ''
+                                                placeholder_title: ''
+                                              third_party_settings: {  }
+                                              type: link_default
+                                              region: content
+                                            field_uiowa_card_title:
+                                              weight: 26
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_feature.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_image
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_link
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_sub
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_title
+                                              - image.style.thumbnail
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_feature.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_feature
+                                          mode: default
+                                          content:
+                                            field_uiowa_feature_image:
+                                              type: image_image
+                                              weight: 29
+                                              settings:
+                                                preview_image_style: thumbnail
+                                                progress_indicator: throbber
+                                              region: content
+                                              third_party_settings: {  }
+                                            field_uiowa_feature_link:
+                                              weight: 28
+                                              settings:
+                                                placeholder_url: ''
+                                                placeholder_title: ''
+                                              third_party_settings: {  }
+                                              type: link_default
+                                              region: content
+                                            field_uiowa_feature_sub:
+                                              weight: 27
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            field_uiowa_feature_title:
+                                              weight: 26
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_noteworthy.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_excerpt
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
+                                              - image.style.thumbnail
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_noteworthy.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_noteworthy
+                                          mode: default
+                                          content:
+                                            field_uiowa_noteworthy_excerpt:
+                                              weight: 30
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textarea
+                                              region: content
+                                            field_uiowa_noteworthy_image:
+                                              type: image_image
+                                              weight: 28
+                                              settings:
+                                                preview_image_style: thumbnail
+                                                progress_indicator: throbber
+                                              region: content
+                                              third_party_settings: {  }
+                                            field_uiowa_noteworthy_link:
+                                              weight: 27
+                                              settings:
+                                                placeholder_url: ''
+                                                placeholder_title: ''
+                                              third_party_settings: {  }
+                                              type: link_default
+                                              region: content
+                                            field_uiowa_noteworthy_sub:
+                                              weight: 29
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            field_uiowa_noteworthy_title:
+                                              weight: 26
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_spacer_separator.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_spacer_separator
+                                              - field.field.block_content.uiowa_spacer_separator.field_uiowa_spacer_separator_txt
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_spacer_separator.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_spacer_separator
+                                          mode: default
+                                          content:
+                                            field_uiowa_spacer_separator_txt:
+                                              weight: 27
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: text_textarea
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_statistic.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_statistic
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
+                                              - image.style.thumbnail
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_statistic.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_statistic
+                                          mode: default
+                                          content:
+                                            field_uiowa_statistic_excerpt:
+                                              weight: 27
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textarea
+                                              region: content
+                                            field_uiowa_statistic_image:
+                                              type: image_image
+                                              weight: 28
+                                              settings:
+                                                preview_image_style: thumbnail
+                                                progress_indicator: throbber
+                                              region: content
+                                              third_party_settings: {  }
+                                            field_uiowa_statistic_title:
+                                              weight: 26
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: string_textfield
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_form_display.block_content.uiowa_text_area.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_text_area
+                                              - field.field.block_content.uiowa_text_area.field_uiowa_text_area
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_text_area.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_text_area
+                                          mode: default
+                                          content:
+                                            field_uiowa_text_area:
+                                              weight: 27
+                                              settings:
+                                                rows: 5
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                              type: text_textarea
+                                              region: content
+                                            info:
+                                              type: string_textfield
+                                              weight: -5
+                                              region: content
+                                              settings:
+                                                size: 60
+                                                placeholder: ''
+                                              third_party_settings: {  }
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_banner.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_image
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_link
+                                              - field.field.block_content.uiowa_banner.field_uiowa_banner_title
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_banner.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_banner
+                                          mode: default
+                                          content:
+                                            field_uiowa_banner_excerpt:
+                                              weight: 1
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: basic_string
+                                              region: content
+                                            field_uiowa_banner_image:
+                                              weight: 3
+                                              label: above
+                                              settings:
+                                                image_style: ''
+                                                image_link: ''
+                                              third_party_settings: {  }
+                                              type: image
+                                              region: content
+                                            field_uiowa_banner_link:
+                                              weight: 2
+                                              label: above
+                                              settings:
+                                                trim_length: 80
+                                                url_only: false
+                                                url_plain: false
+                                                rel: ''
+                                                target: ''
+                                              third_party_settings: {  }
+                                              type: link
+                                              region: content
+                                            field_uiowa_banner_title:
+                                              weight: 0
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_card.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_excerpt
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_image
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_link
+                                              - field.field.block_content.uiowa_card.field_uiowa_card_title
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_card.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_card
+                                          mode: default
+                                          content:
+                                            field_uiowa_card_excerpt:
+                                              weight: 1
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: basic_string
+                                              region: content
+                                            field_uiowa_card_image:
+                                              weight: 3
+                                              label: above
+                                              settings:
+                                                image_style: ''
+                                                image_link: ''
+                                              third_party_settings: {  }
+                                              type: image
+                                              region: content
+                                            field_uiowa_card_link:
+                                              weight: 2
+                                              label: above
+                                              settings:
+                                                trim_length: 80
+                                                url_only: false
+                                                url_plain: false
+                                                rel: ''
+                                                target: ''
+                                              third_party_settings: {  }
+                                              type: link
+                                              region: content
+                                            field_uiowa_card_title:
+                                              weight: 0
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_feature.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_image
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_link
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_sub
+                                              - field.field.block_content.uiowa_feature.field_uiowa_feature_title
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_feature.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_feature
+                                          mode: default
+                                          content:
+                                            field_uiowa_feature_image:
+                                              weight: 3
+                                              label: above
+                                              settings:
+                                                image_style: ''
+                                                image_link: ''
+                                              third_party_settings: {  }
+                                              type: image
+                                              region: content
+                                            field_uiowa_feature_link:
+                                              weight: 2
+                                              label: above
+                                              settings:
+                                                trim_length: 80
+                                                url_only: false
+                                                url_plain: false
+                                                rel: ''
+                                                target: ''
+                                              third_party_settings: {  }
+                                              type: link
+                                              region: content
+                                            field_uiowa_feature_sub:
+                                              weight: 1
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                            field_uiowa_feature_title:
+                                              weight: 0
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_noteworthy.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_excerpt
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
+                                              - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
+                                            module:
+                                              - image
+                                              - link
+                                          id: block_content.uiowa_noteworthy.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_noteworthy
+                                          mode: default
+                                          content:
+                                            field_uiowa_noteworthy_excerpt:
+                                              weight: 4
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: basic_string
+                                              region: content
+                                            field_uiowa_noteworthy_image:
+                                              weight: 2
+                                              label: above
+                                              settings:
+                                                image_style: ''
+                                                image_link: ''
+                                              third_party_settings: {  }
+                                              type: image
+                                              region: content
+                                            field_uiowa_noteworthy_link:
+                                              weight: 1
+                                              label: above
+                                              settings:
+                                                trim_length: 80
+                                                url_only: false
+                                                url_plain: false
+                                                rel: ''
+                                                target: ''
+                                              third_party_settings: {  }
+                                              type: link
+                                              region: content
+                                            field_uiowa_noteworthy_sub:
+                                              weight: 3
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                            field_uiowa_noteworthy_title:
+                                              weight: 0
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_spacer_separator.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_spacer_separator
+                                              - field.field.block_content.uiowa_spacer_separator.field_uiowa_spacer_separator_txt
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_spacer_separator.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_spacer_separator
+                                          mode: default
+                                          content:
+                                            field_uiowa_spacer_separator_txt:
+                                              weight: 1
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: text_default
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_statistic.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_statistic
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
+                                              - field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_statistic.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_statistic
+                                          mode: default
+                                          content:
+                                            field_uiowa_statistic_excerpt:
+                                              weight: 1
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: basic_string
+                                              region: content
+                                            field_uiowa_statistic_image:
+                                              weight: 2
+                                              label: above
+                                              settings:
+                                                image_style: ''
+                                                image_link: ''
+                                              third_party_settings: {  }
+                                              type: image
+                                              region: content
+                                            field_uiowa_statistic_title:
+                                              weight: 0
+                                              label: above
+                                              settings:
+                                                link_to_entity: false
+                                              third_party_settings: {  }
+                                              type: string
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: core.entity_view_display.block_content.uiowa_text_area.default
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_text_area
+                                              - field.field.block_content.uiowa_text_area.field_uiowa_text_area
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_text_area.default
+                                          targetEntityType: block_content
+                                          bundle: uiowa_text_area
+                                          mode: default
+                                          content:
+                                            field_uiowa_text_area:
+                                              weight: 1
+                                              label: above
+                                              settings: {  }
+                                              third_party_settings: {  }
+                                              type: text_default
+                                              region: content
+                                          hidden: {  }
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.storage.block_content.field_uiowa_banner_excerpt
+                                          id: block_content.uiowa_banner.field_uiowa_banner_excerpt
+                                          field_name: field_uiowa_banner_excerpt
+                                          entity_type: block_content
+                                          bundle: uiowa_banner
+                                          label: 'UIowa Banner Excerpt'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string_long
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_banner.field_uiowa_banner_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.storage.block_content.field_uiowa_banner_image
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_banner.field_uiowa_banner_image
+                                          field_name: field_uiowa_banner_image
+                                          entity_type: block_content
+                                          bundle: uiowa_banner
+                                          label: 'UIowa Banner Image'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            file_directory: '[date:custom:Y]-[date:custom:m]'
+                                            file_extensions: 'png gif jpg jpeg'
+                                            max_filesize: ''
+                                            max_resolution: ''
+                                            min_resolution: ''
+                                            alt_field: true
+                                            alt_field_required: true
+                                            title_field: false
+                                            title_field_required: false
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            handler: 'default:file'
+                                            handler_settings: {  }
+                                          field_type: image
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_banner.field_uiowa_banner_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.storage.block_content.field_uiowa_banner_link
+                                            module:
+                                              - link
+                                          id: block_content.uiowa_banner.field_uiowa_banner_link
+                                          field_name: field_uiowa_banner_link
+                                          entity_type: block_content
+                                          bundle: uiowa_banner
+                                          label: 'UIowa Banner Link'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            link_type: 17
+                                            title: 2
+                                          field_type: link
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_banner.field_uiowa_banner_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_banner
+                                              - field.storage.block_content.field_uiowa_banner_title
+                                          id: block_content.uiowa_banner.field_uiowa_banner_title
+                                          field_name: field_uiowa_banner_title
+                                          entity_type: block_content
+                                          bundle: uiowa_banner
+                                          label: 'UIowa Banner Title'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_card.field_uiowa_card_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.storage.block_content.field_uiowa_card_excerpt
+                                          id: block_content.uiowa_card.field_uiowa_card_excerpt
+                                          field_name: field_uiowa_card_excerpt
+                                          entity_type: block_content
+                                          bundle: uiowa_card
+                                          label: 'UIowa Card Excerpt'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string_long
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_card.field_uiowa_card_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.storage.block_content.field_uiowa_card_image
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_card.field_uiowa_card_image
+                                          field_name: field_uiowa_card_image
+                                          entity_type: block_content
+                                          bundle: uiowa_card
+                                          label: 'UIowa Card Image'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            file_directory: '[date:custom:Y]-[date:custom:m]'
+                                            file_extensions: 'png gif jpg jpeg'
+                                            max_filesize: ''
+                                            max_resolution: ''
+                                            min_resolution: ''
+                                            alt_field: true
+                                            alt_field_required: true
+                                            title_field: false
+                                            title_field_required: false
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            handler: 'default:file'
+                                            handler_settings: {  }
+                                          field_type: image
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_card.field_uiowa_card_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.storage.block_content.field_uiowa_card_link
+                                            module:
+                                              - link
+                                          id: block_content.uiowa_card.field_uiowa_card_link
+                                          field_name: field_uiowa_card_link
+                                          entity_type: block_content
+                                          bundle: uiowa_card
+                                          label: 'UIowa Card Link'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            link_type: 17
+                                            title: 2
+                                          field_type: link
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_card.field_uiowa_card_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_card
+                                              - field.storage.block_content.field_uiowa_card_title
+                                          id: block_content.uiowa_card.field_uiowa_card_title
+                                          field_name: field_uiowa_card_title
+                                          entity_type: block_content
+                                          bundle: uiowa_card
+                                          label: 'UIowa Card Title'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_feature.field_uiowa_feature_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.storage.block_content.field_uiowa_feature_image
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_feature.field_uiowa_feature_image
+                                          field_name: field_uiowa_feature_image
+                                          entity_type: block_content
+                                          bundle: uiowa_feature
+                                          label: 'UIowa Feature Image'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            file_directory: '[date:custom:Y]-[date:custom:m]'
+                                            file_extensions: 'png gif jpg jpeg'
+                                            max_filesize: ''
+                                            max_resolution: ''
+                                            min_resolution: ''
+                                            alt_field: true
+                                            alt_field_required: true
+                                            title_field: false
+                                            title_field_required: false
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            handler: 'default:file'
+                                            handler_settings: {  }
+                                          field_type: image
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_feature.field_uiowa_feature_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.storage.block_content.field_uiowa_feature_link
+                                            module:
+                                              - link
+                                          id: block_content.uiowa_feature.field_uiowa_feature_link
+                                          field_name: field_uiowa_feature_link
+                                          entity_type: block_content
+                                          bundle: uiowa_feature
+                                          label: 'UIowa Feature Link'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            link_type: 17
+                                            title: 1
+                                          field_type: link
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_feature.field_uiowa_feature_sub
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.storage.block_content.field_uiowa_feature_sub
+                                          id: block_content.uiowa_feature.field_uiowa_feature_sub
+                                          field_name: field_uiowa_feature_sub
+                                          entity_type: block_content
+                                          bundle: uiowa_feature
+                                          label: 'UIowa Feature Sub'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_feature.field_uiowa_feature_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_feature
+                                              - field.storage.block_content.field_uiowa_feature_title
+                                          id: block_content.uiowa_feature.field_uiowa_feature_title
+                                          field_name: field_uiowa_feature_title
+                                          entity_type: block_content
+                                          bundle: uiowa_feature
+                                          label: 'UIowa Feature Title'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.storage.block_content.field_uiowa_noteworthy_excerpt
+                                          id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_excerpt
+                                          field_name: field_uiowa_noteworthy_excerpt
+                                          entity_type: block_content
+                                          bundle: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy Excerpt'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string_long
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.storage.block_content.field_uiowa_noteworthy_image
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
+                                          field_name: field_uiowa_noteworthy_image
+                                          entity_type: block_content
+                                          bundle: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy Image'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            file_directory: '[date:custom:Y]-[date:custom:m]'
+                                            file_extensions: 'png gif jpg jpeg'
+                                            max_filesize: ''
+                                            max_resolution: ''
+                                            min_resolution: ''
+                                            alt_field: true
+                                            alt_field_required: true
+                                            title_field: false
+                                            title_field_required: false
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            handler: 'default:file'
+                                            handler_settings: {  }
+                                          field_type: image
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.storage.block_content.field_uiowa_noteworthy_link
+                                            module:
+                                              - link
+                                          id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
+                                          field_name: field_uiowa_noteworthy_link
+                                          entity_type: block_content
+                                          bundle: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy Link'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            link_type: 17
+                                            title: 2
+                                          field_type: link
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.storage.block_content.field_uiowa_noteworthy_sub
+                                          id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
+                                          field_name: field_uiowa_noteworthy_sub
+                                          entity_type: block_content
+                                          bundle: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy Sub'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_noteworthy
+                                              - field.storage.block_content.field_uiowa_noteworthy_title
+                                          id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
+                                          field_name: field_uiowa_noteworthy_title
+                                          entity_type: block_content
+                                          bundle: uiowa_noteworthy
+                                          label: 'UIowa Noteworthy Title'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_spacer_separator.field_uiowa_spacer_separator_txt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_spacer_separator
+                                              - field.storage.block_content.field_uiowa_spacer_separator_txt
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_spacer_separator.field_uiowa_spacer_separator_txt
+                                          field_name: field_uiowa_spacer_separator_txt
+                                          entity_type: block_content
+                                          bundle: uiowa_spacer_separator
+                                          label: 'UIowa Spacer/Separator Text'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: text_long
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_statistic
+                                              - field.storage.block_content.field_uiowa_statistic_excerpt
+                                          id: block_content.uiowa_statistic.field_uiowa_statistic_excerpt
+                                          field_name: field_uiowa_statistic_excerpt
+                                          entity_type: block_content
+                                          bundle: uiowa_statistic
+                                          label: 'UIowa Statistic Excerpt'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string_long
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_statistic
+                                              - field.storage.block_content.field_uiowa_statistic_image
+                                            module:
+                                              - image
+                                          id: block_content.uiowa_statistic.field_uiowa_statistic_image
+                                          field_name: field_uiowa_statistic_image
+                                          entity_type: block_content
+                                          bundle: uiowa_statistic
+                                          label: 'UIowa Statistic Image'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings:
+                                            file_directory: '[date:custom:Y]-[date:custom:m]'
+                                            file_extensions: 'png gif jpg jpeg'
+                                            max_filesize: ''
+                                            max_resolution: ''
+                                            min_resolution: ''
+                                            alt_field: true
+                                            alt_field_required: true
+                                            title_field: false
+                                            title_field_required: false
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            handler: 'default:file'
+                                            handler_settings: {  }
+                                          field_type: image
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_statistic
+                                              - field.storage.block_content.field_uiowa_statistic_title
+                                          id: block_content.uiowa_statistic.field_uiowa_statistic_title
+                                          field_name: field_uiowa_statistic_title
+                                          entity_type: block_content
+                                          bundle: uiowa_statistic
+                                          label: 'UIowa Statistic Title'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: string
+                                      -
+                                        collection: ''
+                                        name: field.field.block_content.uiowa_text_area.field_uiowa_text_area
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            config:
+                                              - block_content.type.uiowa_text_area
+                                              - field.storage.block_content.field_uiowa_text_area
+                                            module:
+                                              - text
+                                          id: block_content.uiowa_text_area.field_uiowa_text_area
+                                          field_name: field_uiowa_text_area
+                                          entity_type: block_content
+                                          bundle: uiowa_text_area
+                                          label: 'UIowa Text Area'
+                                          description: ''
+                                          required: false
+                                          translatable: false
+                                          default_value: {  }
+                                          default_value_callback: ''
+                                          settings: {  }
+                                          field_type: text_long
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_banner_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_banner_excerpt
+                                          field_name: field_uiowa_banner_excerpt
+                                          entity_type: block_content
+                                          type: string_long
+                                          settings:
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_banner_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - file
+                                              - image
+                                          id: block_content.field_uiowa_banner_image
+                                          field_name: field_uiowa_banner_image
+                                          entity_type: block_content
+                                          type: image
+                                          settings:
+                                            uri_scheme: public
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            target_type: file
+                                            display_field: false
+                                            display_default: false
+                                          module: image
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_banner_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - link
+                                          id: block_content.field_uiowa_banner_link
+                                          field_name: field_uiowa_banner_link
+                                          entity_type: block_content
+                                          type: link
+                                          settings: {  }
+                                          module: link
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_banner_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_banner_title
+                                          field_name: field_uiowa_banner_title
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_card_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_card_excerpt
+                                          field_name: field_uiowa_card_excerpt
+                                          entity_type: block_content
+                                          type: string_long
+                                          settings:
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_card_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - file
+                                              - image
+                                          id: block_content.field_uiowa_card_image
+                                          field_name: field_uiowa_card_image
+                                          entity_type: block_content
+                                          type: image
+                                          settings:
+                                            uri_scheme: public
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            target_type: file
+                                            display_field: false
+                                            display_default: false
+                                          module: image
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_card_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - link
+                                          id: block_content.field_uiowa_card_link
+                                          field_name: field_uiowa_card_link
+                                          entity_type: block_content
+                                          type: link
+                                          settings: {  }
+                                          module: link
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_card_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_card_title
+                                          field_name: field_uiowa_card_title
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_feature_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - file
+                                              - image
+                                          id: block_content.field_uiowa_feature_image
+                                          field_name: field_uiowa_feature_image
+                                          entity_type: block_content
+                                          type: image
+                                          settings:
+                                            uri_scheme: public
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            target_type: file
+                                            display_field: false
+                                            display_default: false
+                                          module: image
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_feature_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - link
+                                          id: block_content.field_uiowa_feature_link
+                                          field_name: field_uiowa_feature_link
+                                          entity_type: block_content
+                                          type: link
+                                          settings: {  }
+                                          module: link
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_feature_sub
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_feature_sub
+                                          field_name: field_uiowa_feature_sub
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_feature_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_feature_title
+                                          field_name: field_uiowa_feature_title
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_noteworthy_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_noteworthy_excerpt
+                                          field_name: field_uiowa_noteworthy_excerpt
+                                          entity_type: block_content
+                                          type: string_long
+                                          settings:
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_noteworthy_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - file
+                                              - image
+                                          id: block_content.field_uiowa_noteworthy_image
+                                          field_name: field_uiowa_noteworthy_image
+                                          entity_type: block_content
+                                          type: image
+                                          settings:
+                                            uri_scheme: public
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            target_type: file
+                                            display_field: false
+                                            display_default: false
+                                          module: image
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_noteworthy_link
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - link
+                                          id: block_content.field_uiowa_noteworthy_link
+                                          field_name: field_uiowa_noteworthy_link
+                                          entity_type: block_content
+                                          type: link
+                                          settings: {  }
+                                          module: link
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_noteworthy_sub
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_noteworthy_sub
+                                          field_name: field_uiowa_noteworthy_sub
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_noteworthy_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_noteworthy_title
+                                          field_name: field_uiowa_noteworthy_title
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_spacer_separator_txt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - text
+                                          id: block_content.field_uiowa_spacer_separator_txt
+                                          field_name: field_uiowa_spacer_separator_txt
+                                          entity_type: block_content
+                                          type: text_long
+                                          settings: {  }
+                                          module: text
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_statistic_excerpt
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_statistic_excerpt
+                                          field_name: field_uiowa_statistic_excerpt
+                                          entity_type: block_content
+                                          type: string_long
+                                          settings:
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_statistic_image
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - file
+                                              - image
+                                          id: block_content.field_uiowa_statistic_image
+                                          field_name: field_uiowa_statistic_image
+                                          entity_type: block_content
+                                          type: image
+                                          settings:
+                                            uri_scheme: public
+                                            default_image:
+                                              uuid: ''
+                                              alt: ''
+                                              title: ''
+                                              width: null
+                                              height: null
+                                            target_type: file
+                                            display_field: false
+                                            display_default: false
+                                          module: image
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_statistic_title
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                          id: block_content.field_uiowa_statistic_title
+                                          field_name: field_uiowa_statistic_title
+                                          entity_type: block_content
+                                          type: string
+                                          settings:
+                                            max_length: 255
+                                            is_ascii: false
+                                            case_sensitive: false
+                                          module: core
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: field.storage.block_content.field_uiowa_text_area
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies:
+                                            module:
+                                              - block_content
+                                              - text
+                                          id: block_content.field_uiowa_text_area
+                                          field_name: field_uiowa_text_area
+                                          entity_type: block_content
+                                          type: text_long
+                                          settings: {  }
+                                          module: text
+                                          locked: false
+                                          cardinality: 1
+                                          translatable: true
+                                          indexes: {  }
+                                          persist_with_no_fields: false
+                                          custom_storage: false
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.settings
+                                        data:
+                                          multiselect: single
+                                          form_type: checkboxes
+                                          groups: "padding|Padding\r\nmargin|Margin\r\nsection|Section"
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.style.container
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: container
+                                          label: 'Margin Left/Right Auto: Fixed Width Container'
+                                          classes: page__container
+                                          type: section
+                                          group: margin
+                                          block_restrictions: {  }
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.style.feature_block_section_w_expanding_blocks
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: feature_block_section_w_expanding_blocks
+                                          label: 'Section: Feature Block Section w/Expanding Blocks'
+                                          classes: "feature__container\r\nfeature__container-expanded"
+                                          type: section
+                                          group: section_type
+                                          block_restrictions: {  }
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.style.section_margin_bottom_only
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: section_margin_bottom_only
+                                          label: 'Margin: Bottom Only'
+                                          classes: section-margin__bottom
+                                          type: section
+                                          group: margin
+                                          block_restrictions: {  }
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.style.section_margin_top_bottom
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: section_margin_top_bottom
+                                          label: 'Margin: Top/Bottom'
+                                          classes: section-margin
+                                          type: section
+                                          group: margin
+                                          block_restrictions: {  }
+                                      -
+                                        collection: ''
+                                        name: layout_builder_styles.style.section_margin_top_only
+                                        data:
+                                          langcode: en
+                                          status: true
+                                          dependencies: {  }
+                                          id: section_margin_top_only
+                                          label: 'Margin: Margin Top Only'
+                                          classes: section-margin__top
+                                          type: section
+                                          group: margin
+                                          block_restrictions: {  }
+                                -
+                                  collection: ''
                                   name: core.entity_form_display.block_content.uiowa_banner.default
                                   data:
                                     langcode: en
@@ -2416,7 +4449,7 @@ items:
                                   data:
                                     multiselect: single
                                     form_type: checkboxes
-                                    groups: "padding|Padding\r\nmargin|Margin\r\nsection|Section"
+                                    groups: "padding|Padding\r\nmargin|Margin\r\nsection_type|Section"
                                 -
                                   collection: ''
                                   name: layout_builder_styles.style.container
@@ -2440,6 +4473,45 @@ items:
                                     id: feature_block_section_w_expanding_blocks
                                     label: 'Section: Feature Block Section w/Expanding Blocks'
                                     classes: "feature__container\r\nfeature__container-expanded"
+                                    type: section
+                                    group: section_type
+                                    block_restrictions: {  }
+                                -
+                                  collection: ''
+                                  name: layout_builder_styles.style.padding_add_padding_to_left_and_right_side_of_container
+                                  data:
+                                    langcode: en
+                                    status: true
+                                    dependencies: {  }
+                                    id: padding_add_padding_to_left_and_right_side_of_container
+                                    label: 'Padding: Add padding to left and right side of container'
+                                    classes: section-padding__side
+                                    type: section
+                                    group: padding
+                                    block_restrictions: {  }
+                                -
+                                  collection: ''
+                                  name: layout_builder_styles.style.padding_remove_default_column_padding
+                                  data:
+                                    langcode: en
+                                    status: true
+                                    dependencies: {  }
+                                    id: padding_remove_default_column_padding
+                                    label: 'Padding: Remove Default Column Padding'
+                                    classes: section-padding__removed
+                                    type: section
+                                    group: padding
+                                    block_restrictions: {  }
+                                -
+                                  collection: ''
+                                  name: layout_builder_styles.style.section_display_columns_in_a_row_instead_of_stacking
+                                  data:
+                                    langcode: en
+                                    status: true
+                                    dependencies: {  }
+                                    id: section_display_columns_in_a_row_instead_of_stacking
+                                    label: 'Section: Display content within section columns in a row instead of a stack'
+                                    classes: section-column__row
                                     type: section
                                     group: section_type
                                     block_restrictions: {  }
@@ -4367,7 +6439,7 @@ items:
                               status: true
                               dependencies: {  }
                               id: container
-                              label: 'Margin Left/Right Auto: Fixed Width Container'
+                              label: 'Margin: Left/Right Auto Fixed Width Container'
                               classes: page__container
                               type: section
                               group: margin
@@ -4384,6 +6456,19 @@ items:
                               classes: "feature__container\r\nfeature__container-expanded"
                               type: section
                               group: section_type
+                              block_restrictions: {  }
+                          -
+                            collection: ''
+                            name: layout_builder_styles.style.margin_full_width_container
+                            data:
+                              langcode: en
+                              status: true
+                              dependencies: {  }
+                              id: margin_full_width_container
+                              label: 'Margin: Full Width Container'
+                              classes: page__container--full
+                              type: section
+                              group: margin
                               block_restrictions: {  }
                           -
                             collection: ''
@@ -4476,10 +6561,9 @@ items:
                             - field.field.block_content.uiowa_banner.field_uiowa_banner_image
                             - field.field.block_content.uiowa_banner.field_uiowa_banner_link
                             - field.field.block_content.uiowa_banner.field_uiowa_banner_title
-                            - image.style.thumbnail
                           module:
-                            - image
                             - link
+                            - media_library
                         id: block_content.uiowa_banner.default
                         targetEntityType: block_content
                         bundle: uiowa_banner
@@ -4494,11 +6578,18 @@ items:
                             type: string_textarea
                             region: content
                           field_uiowa_banner_image:
-                            type: image_image
+                            type: entity_browser_entity_reference
                             weight: 29
                             settings:
-                              preview_image_style: thumbnail
-                              progress_indicator: throbber
+                              entity_browser: media_browser
+                              field_widget_display: rendered_entity
+                              field_widget_edit: true
+                              field_widget_remove: true
+                              selection_mode: selection_append
+                              field_widget_display_settings:
+                                view_mode: thumbnail
+                              open: true
+                              field_widget_replace: false
                             region: content
                             third_party_settings: {  }
                           field_uiowa_banner_link:
@@ -4539,10 +6630,9 @@ items:
                             - field.field.block_content.uiowa_card.field_uiowa_card_image
                             - field.field.block_content.uiowa_card.field_uiowa_card_link
                             - field.field.block_content.uiowa_card.field_uiowa_card_title
-                            - image.style.thumbnail
                           module:
-                            - image
                             - link
+                            - media_library
                         id: block_content.uiowa_card.default
                         targetEntityType: block_content
                         bundle: uiowa_card
@@ -4557,11 +6647,18 @@ items:
                             type: string_textarea
                             region: content
                           field_uiowa_card_image:
-                            type: image_image
+                            type: entity_browser_entity_reference
                             weight: 29
                             settings:
-                              preview_image_style: thumbnail
-                              progress_indicator: throbber
+                              entity_browser: media_browser
+                              field_widget_display: rendered_entity
+                              field_widget_edit: true
+                              field_widget_remove: true
+                              selection_mode: selection_append
+                              field_widget_display_settings:
+                                view_mode: thumbnail
+                              open: true
+                              field_widget_replace: false
                             region: content
                             third_party_settings: {  }
                           field_uiowa_card_link:
@@ -4602,21 +6699,27 @@ items:
                             - field.field.block_content.uiowa_feature.field_uiowa_feature_link
                             - field.field.block_content.uiowa_feature.field_uiowa_feature_sub
                             - field.field.block_content.uiowa_feature.field_uiowa_feature_title
-                            - image.style.thumbnail
                           module:
-                            - image
                             - link
+                            - media_library
                         id: block_content.uiowa_feature.default
                         targetEntityType: block_content
                         bundle: uiowa_feature
                         mode: default
                         content:
                           field_uiowa_feature_image:
-                            type: image_image
+                            type: entity_browser_entity_reference
                             weight: 29
                             settings:
-                              preview_image_style: thumbnail
-                              progress_indicator: throbber
+                              entity_browser: media_browser
+                              field_widget_display: rendered_entity
+                              field_widget_edit: true
+                              field_widget_remove: true
+                              selection_mode: selection_append
+                              field_widget_display_settings:
+                                view_mode: thumbnail
+                              open: true
+                              field_widget_replace: false
                             region: content
                             third_party_settings: {  }
                           field_uiowa_feature_link:
@@ -4666,10 +6769,9 @@ items:
                             - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
                             - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
                             - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
-                            - image.style.thumbnail
                           module:
-                            - image
                             - link
+                            - media_library
                         id: block_content.uiowa_noteworthy.default
                         targetEntityType: block_content
                         bundle: uiowa_noteworthy
@@ -4684,11 +6786,18 @@ items:
                             type: string_textarea
                             region: content
                           field_uiowa_noteworthy_image:
-                            type: image_image
-                            weight: 28
+                            type: entity_browser_entity_reference
+                            weight: 31
                             settings:
-                              preview_image_style: thumbnail
-                              progress_indicator: throbber
+                              entity_browser: media_browser
+                              field_widget_display: rendered_entity
+                              field_widget_edit: true
+                              field_widget_remove: true
+                              selection_mode: selection_append
+                              field_widget_display_settings:
+                                view_mode: thumbnail
+                              open: true
+                              field_widget_replace: false
                             region: content
                             third_party_settings: {  }
                           field_uiowa_noteworthy_link:
@@ -4770,9 +6879,8 @@ items:
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
-                            - image.style.thumbnail
                           module:
-                            - image
+                            - media_library
                         id: block_content.uiowa_statistic.default
                         targetEntityType: block_content
                         bundle: uiowa_statistic
@@ -4787,11 +6895,18 @@ items:
                             type: string_textarea
                             region: content
                           field_uiowa_statistic_image:
-                            type: image_image
+                            type: entity_browser_entity_reference
                             weight: 28
                             settings:
-                              preview_image_style: thumbnail
-                              progress_indicator: throbber
+                              entity_browser: media_browser
+                              field_widget_display: rendered_entity
+                              field_widget_edit: true
+                              field_widget_remove: true
+                              selection_mode: selection_append
+                              field_widget_display_settings:
+                                view_mode: thumbnail
+                              open: true
+                              field_widget_replace: false
                             region: content
                             third_party_settings: {  }
                           field_uiowa_statistic_title:
@@ -4859,7 +6974,6 @@ items:
                             - field.field.block_content.uiowa_banner.field_uiowa_banner_link
                             - field.field.block_content.uiowa_banner.field_uiowa_banner_title
                           module:
-                            - image
                             - link
                         id: block_content.uiowa_banner.default
                         targetEntityType: block_content
@@ -4874,13 +6988,13 @@ items:
                             type: basic_string
                             region: content
                           field_uiowa_banner_image:
+                            type: entity_reference_entity_view
                             weight: 3
                             label: above
                             settings:
-                              image_style: ''
-                              image_link: ''
+                              view_mode: default
+                              link: false
                             third_party_settings: {  }
-                            type: image
                             region: content
                           field_uiowa_banner_link:
                             weight: 2
@@ -4917,7 +7031,6 @@ items:
                             - field.field.block_content.uiowa_card.field_uiowa_card_link
                             - field.field.block_content.uiowa_card.field_uiowa_card_title
                           module:
-                            - image
                             - link
                         id: block_content.uiowa_card.default
                         targetEntityType: block_content
@@ -4932,13 +7045,13 @@ items:
                             type: basic_string
                             region: content
                           field_uiowa_card_image:
+                            type: entity_reference_entity_view
                             weight: 3
                             label: above
                             settings:
-                              image_style: ''
-                              image_link: ''
+                              view_mode: default
+                              link: false
                             third_party_settings: {  }
-                            type: image
                             region: content
                           field_uiowa_card_link:
                             weight: 2
@@ -4975,7 +7088,6 @@ items:
                             - field.field.block_content.uiowa_feature.field_uiowa_feature_sub
                             - field.field.block_content.uiowa_feature.field_uiowa_feature_title
                           module:
-                            - image
                             - link
                         id: block_content.uiowa_feature.default
                         targetEntityType: block_content
@@ -4983,13 +7095,13 @@ items:
                         mode: default
                         content:
                           field_uiowa_feature_image:
+                            type: entity_reference_entity_view
                             weight: 3
                             label: above
                             settings:
-                              image_style: ''
-                              image_link: ''
+                              view_mode: default
+                              link: false
                             third_party_settings: {  }
-                            type: image
                             region: content
                           field_uiowa_feature_link:
                             weight: 2
@@ -5035,7 +7147,6 @@ items:
                             - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
                             - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
                           module:
-                            - image
                             - link
                         id: block_content.uiowa_noteworthy.default
                         targetEntityType: block_content
@@ -5050,13 +7161,13 @@ items:
                             type: basic_string
                             region: content
                           field_uiowa_noteworthy_image:
-                            weight: 2
+                            type: entity_reference_entity_view
+                            weight: 5
                             label: above
                             settings:
-                              image_style: ''
-                              image_link: ''
+                              view_mode: default
+                              link: false
                             third_party_settings: {  }
-                            type: image
                             region: content
                           field_uiowa_noteworthy_link:
                             weight: 1
@@ -5124,8 +7235,6 @@ items:
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
                             - field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
-                          module:
-                            - image
                         id: block_content.uiowa_statistic.default
                         targetEntityType: block_content
                         bundle: uiowa_statistic
@@ -5139,13 +7248,13 @@ items:
                             type: basic_string
                             region: content
                           field_uiowa_statistic_image:
+                            type: entity_reference_entity_view
                             weight: 2
                             label: above
                             settings:
-                              image_style: ''
-                              image_link: ''
+                              view_mode: default
+                              link: false
                             third_party_settings: {  }
-                            type: image
                             region: content
                           field_uiowa_statistic_title:
                             weight: 0
@@ -5195,7 +7304,7 @@ items:
                         field_name: field_uiowa_banner_excerpt
                         entity_type: block_content
                         bundle: uiowa_banner
-                        label: 'UIowa Banner Excerpt'
+                        label: Excerpt
                         description: ''
                         required: false
                         translatable: false
@@ -5213,37 +7322,27 @@ items:
                           config:
                             - block_content.type.uiowa_banner
                             - field.storage.block_content.field_uiowa_banner_image
-                          module:
-                            - image
+                            - media.type.image
                         id: block_content.uiowa_banner.field_uiowa_banner_image
                         field_name: field_uiowa_banner_image
                         entity_type: block_content
                         bundle: uiowa_banner
-                        label: 'UIowa Banner Image'
+                        label: Image
                         description: ''
                         required: false
                         translatable: false
                         default_value: {  }
                         default_value_callback: ''
                         settings:
-                          file_directory: '[date:custom:Y]-[date:custom:m]'
-                          file_extensions: 'png gif jpg jpeg'
-                          max_filesize: ''
-                          max_resolution: ''
-                          min_resolution: ''
-                          alt_field: true
-                          alt_field_required: true
-                          title_field: false
-                          title_field_required: false
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          handler: 'default:file'
-                          handler_settings: {  }
-                        field_type: image
+                          handler: 'default:media'
+                          handler_settings:
+                            target_bundles:
+                              image: image
+                            sort:
+                              field: _none
+                            auto_create: false
+                            auto_create_bundle: ''
+                        field_type: entity_reference
                     -
                       collection: ''
                       name: field.field.block_content.uiowa_banner.field_uiowa_banner_link
@@ -5260,7 +7359,7 @@ items:
                         field_name: field_uiowa_banner_link
                         entity_type: block_content
                         bundle: uiowa_banner
-                        label: 'UIowa Banner Link'
+                        label: Link
                         description: ''
                         required: false
                         translatable: false
@@ -5284,7 +7383,7 @@ items:
                         field_name: field_uiowa_banner_title
                         entity_type: block_content
                         bundle: uiowa_banner
-                        label: 'UIowa Banner Title'
+                        label: Title
                         description: ''
                         required: false
                         translatable: false
@@ -5306,7 +7405,7 @@ items:
                         field_name: field_uiowa_card_excerpt
                         entity_type: block_content
                         bundle: uiowa_card
-                        label: 'UIowa Card Excerpt'
+                        label: Excerpt
                         description: ''
                         required: false
                         translatable: false
@@ -5324,37 +7423,27 @@ items:
                           config:
                             - block_content.type.uiowa_card
                             - field.storage.block_content.field_uiowa_card_image
-                          module:
-                            - image
+                            - media.type.image
                         id: block_content.uiowa_card.field_uiowa_card_image
                         field_name: field_uiowa_card_image
                         entity_type: block_content
                         bundle: uiowa_card
-                        label: 'UIowa Card Image'
+                        label: Image
                         description: ''
                         required: false
                         translatable: false
                         default_value: {  }
                         default_value_callback: ''
                         settings:
-                          file_directory: '[date:custom:Y]-[date:custom:m]'
-                          file_extensions: 'png gif jpg jpeg'
-                          max_filesize: ''
-                          max_resolution: ''
-                          min_resolution: ''
-                          alt_field: true
-                          alt_field_required: true
-                          title_field: false
-                          title_field_required: false
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          handler: 'default:file'
-                          handler_settings: {  }
-                        field_type: image
+                          handler: 'default:media'
+                          handler_settings:
+                            target_bundles:
+                              image: image
+                            sort:
+                              field: _none
+                            auto_create: false
+                            auto_create_bundle: ''
+                        field_type: entity_reference
                     -
                       collection: ''
                       name: field.field.block_content.uiowa_card.field_uiowa_card_link
@@ -5371,7 +7460,7 @@ items:
                         field_name: field_uiowa_card_link
                         entity_type: block_content
                         bundle: uiowa_card
-                        label: 'UIowa Card Link'
+                        label: Link
                         description: ''
                         required: false
                         translatable: false
@@ -5395,7 +7484,7 @@ items:
                         field_name: field_uiowa_card_title
                         entity_type: block_content
                         bundle: uiowa_card
-                        label: 'UIowa Card Title'
+                        label: Title
                         description: ''
                         required: false
                         translatable: false
@@ -5413,37 +7502,27 @@ items:
                           config:
                             - block_content.type.uiowa_feature
                             - field.storage.block_content.field_uiowa_feature_image
-                          module:
-                            - image
+                            - media.type.image
                         id: block_content.uiowa_feature.field_uiowa_feature_image
                         field_name: field_uiowa_feature_image
                         entity_type: block_content
                         bundle: uiowa_feature
-                        label: 'UIowa Feature Image'
+                        label: Image
                         description: ''
                         required: false
                         translatable: false
                         default_value: {  }
                         default_value_callback: ''
                         settings:
-                          file_directory: '[date:custom:Y]-[date:custom:m]'
-                          file_extensions: 'png gif jpg jpeg'
-                          max_filesize: ''
-                          max_resolution: ''
-                          min_resolution: ''
-                          alt_field: true
-                          alt_field_required: true
-                          title_field: false
-                          title_field_required: false
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          handler: 'default:file'
-                          handler_settings: {  }
-                        field_type: image
+                          handler: 'default:media'
+                          handler_settings:
+                            target_bundles:
+                              image: image
+                            sort:
+                              field: _none
+                            auto_create: false
+                            auto_create_bundle: ''
+                        field_type: entity_reference
                     -
                       collection: ''
                       name: field.field.block_content.uiowa_feature.field_uiowa_feature_link
@@ -5460,7 +7539,7 @@ items:
                         field_name: field_uiowa_feature_link
                         entity_type: block_content
                         bundle: uiowa_feature
-                        label: 'UIowa Feature Link'
+                        label: Link
                         description: ''
                         required: false
                         translatable: false
@@ -5484,7 +7563,7 @@ items:
                         field_name: field_uiowa_feature_sub
                         entity_type: block_content
                         bundle: uiowa_feature
-                        label: 'UIowa Feature Sub'
+                        label: 'Sub Heading'
                         description: ''
                         required: false
                         translatable: false
@@ -5506,7 +7585,7 @@ items:
                         field_name: field_uiowa_feature_title
                         entity_type: block_content
                         bundle: uiowa_feature
-                        label: 'UIowa Feature Title'
+                        label: Title
                         description: ''
                         required: false
                         translatable: false
@@ -5528,7 +7607,7 @@ items:
                         field_name: field_uiowa_noteworthy_excerpt
                         entity_type: block_content
                         bundle: uiowa_noteworthy
-                        label: 'UIowa Noteworthy Excerpt'
+                        label: Excerpt
                         description: ''
                         required: false
                         translatable: false
@@ -5546,37 +7625,27 @@ items:
                           config:
                             - block_content.type.uiowa_noteworthy
                             - field.storage.block_content.field_uiowa_noteworthy_image
-                          module:
-                            - image
+                            - media.type.image
                         id: block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
                         field_name: field_uiowa_noteworthy_image
                         entity_type: block_content
                         bundle: uiowa_noteworthy
-                        label: 'UIowa Noteworthy Image'
+                        label: Image
                         description: ''
                         required: false
                         translatable: false
                         default_value: {  }
                         default_value_callback: ''
                         settings:
-                          file_directory: '[date:custom:Y]-[date:custom:m]'
-                          file_extensions: 'png gif jpg jpeg'
-                          max_filesize: ''
-                          max_resolution: ''
-                          min_resolution: ''
-                          alt_field: true
-                          alt_field_required: true
-                          title_field: false
-                          title_field_required: false
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          handler: 'default:file'
-                          handler_settings: {  }
-                        field_type: image
+                          handler: 'default:media'
+                          handler_settings:
+                            target_bundles:
+                              image: image
+                            sort:
+                              field: _none
+                            auto_create: false
+                            auto_create_bundle: ''
+                        field_type: entity_reference
                     -
                       collection: ''
                       name: field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
@@ -5593,7 +7662,7 @@ items:
                         field_name: field_uiowa_noteworthy_link
                         entity_type: block_content
                         bundle: uiowa_noteworthy
-                        label: 'UIowa Noteworthy Link'
+                        label: Link
                         description: ''
                         required: false
                         translatable: false
@@ -5617,7 +7686,7 @@ items:
                         field_name: field_uiowa_noteworthy_sub
                         entity_type: block_content
                         bundle: uiowa_noteworthy
-                        label: 'UIowa Noteworthy Sub'
+                        label: 'Sub Heading'
                         description: ''
                         required: false
                         translatable: false
@@ -5639,7 +7708,7 @@ items:
                         field_name: field_uiowa_noteworthy_title
                         entity_type: block_content
                         bundle: uiowa_noteworthy
-                        label: 'UIowa Noteworthy Title'
+                        label: Title
                         description: ''
                         required: false
                         translatable: false
@@ -5663,7 +7732,7 @@ items:
                         field_name: field_uiowa_spacer_separator_txt
                         entity_type: block_content
                         bundle: uiowa_spacer_separator
-                        label: 'UIowa Spacer/Separator Text'
+                        label: 'Spacer/Separator Text'
                         description: ''
                         required: false
                         translatable: false
@@ -5685,7 +7754,7 @@ items:
                         field_name: field_uiowa_statistic_excerpt
                         entity_type: block_content
                         bundle: uiowa_statistic
-                        label: 'UIowa Statistic Excerpt'
+                        label: Excerpt
                         description: ''
                         required: false
                         translatable: false
@@ -5703,37 +7772,27 @@ items:
                           config:
                             - block_content.type.uiowa_statistic
                             - field.storage.block_content.field_uiowa_statistic_image
-                          module:
-                            - image
+                            - media.type.image
                         id: block_content.uiowa_statistic.field_uiowa_statistic_image
                         field_name: field_uiowa_statistic_image
                         entity_type: block_content
                         bundle: uiowa_statistic
-                        label: 'UIowa Statistic Image'
+                        label: Image
                         description: ''
                         required: false
                         translatable: false
                         default_value: {  }
                         default_value_callback: ''
                         settings:
-                          file_directory: '[date:custom:Y]-[date:custom:m]'
-                          file_extensions: 'png gif jpg jpeg'
-                          max_filesize: ''
-                          max_resolution: ''
-                          min_resolution: ''
-                          alt_field: true
-                          alt_field_required: true
-                          title_field: false
-                          title_field_required: false
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          handler: 'default:file'
-                          handler_settings: {  }
-                        field_type: image
+                          handler: 'default:media'
+                          handler_settings:
+                            target_bundles:
+                              image: image
+                            sort:
+                              field: _none
+                            auto_create: false
+                            auto_create_bundle: ''
+                        field_type: entity_reference
                     -
                       collection: ''
                       name: field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
@@ -5748,7 +7807,7 @@ items:
                         field_name: field_uiowa_statistic_title
                         entity_type: block_content
                         bundle: uiowa_statistic
-                        label: 'UIowa Statistic Title'
+                        label: Title
                         description: ''
                         required: false
                         translatable: false
@@ -5772,7 +7831,7 @@ items:
                         field_name: field_uiowa_text_area
                         entity_type: block_content
                         bundle: uiowa_text_area
-                        label: 'UIowa Text Area'
+                        label: 'Text Area'
                         description: ''
                         required: false
                         translatable: false
@@ -5811,24 +7870,14 @@ items:
                         dependencies:
                           module:
                             - block_content
-                            - file
-                            - image
+                            - media
                         id: block_content.field_uiowa_banner_image
                         field_name: field_uiowa_banner_image
                         entity_type: block_content
-                        type: image
+                        type: entity_reference
                         settings:
-                          uri_scheme: public
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          target_type: file
-                          display_field: false
-                          display_default: false
-                        module: image
+                          target_type: media
+                        module: core
                         locked: false
                         cardinality: 1
                         translatable: true
@@ -5912,24 +7961,14 @@ items:
                         dependencies:
                           module:
                             - block_content
-                            - file
-                            - image
+                            - media
                         id: block_content.field_uiowa_card_image
                         field_name: field_uiowa_card_image
                         entity_type: block_content
-                        type: image
+                        type: entity_reference
                         settings:
-                          uri_scheme: public
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          target_type: file
-                          display_field: false
-                          display_default: false
-                        module: image
+                          target_type: media
+                        module: core
                         locked: false
                         cardinality: 1
                         translatable: true
@@ -5991,24 +8030,14 @@ items:
                         dependencies:
                           module:
                             - block_content
-                            - file
-                            - image
+                            - media
                         id: block_content.field_uiowa_feature_image
                         field_name: field_uiowa_feature_image
                         entity_type: block_content
-                        type: image
+                        type: entity_reference
                         settings:
-                          uri_scheme: public
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          target_type: file
-                          display_field: false
-                          display_default: false
-                        module: image
+                          target_type: media
+                        module: core
                         locked: false
                         cardinality: 1
                         translatable: true
@@ -6116,24 +8145,14 @@ items:
                         dependencies:
                           module:
                             - block_content
-                            - file
-                            - image
+                            - media
                         id: block_content.field_uiowa_noteworthy_image
                         field_name: field_uiowa_noteworthy_image
                         entity_type: block_content
-                        type: image
+                        type: entity_reference
                         settings:
-                          uri_scheme: public
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          target_type: file
-                          display_field: false
-                          display_default: false
-                        module: image
+                          target_type: media
+                        module: core
                         locked: false
                         cardinality: 1
                         translatable: true
@@ -6263,24 +8282,14 @@ items:
                         dependencies:
                           module:
                             - block_content
-                            - file
-                            - image
+                            - media
                         id: block_content.field_uiowa_statistic_image
                         field_name: field_uiowa_statistic_image
                         entity_type: block_content
-                        type: image
+                        type: entity_reference
                         settings:
-                          uri_scheme: public
-                          default_image:
-                            uuid: ''
-                            alt: ''
-                            title: ''
-                            width: null
-                            height: null
-                          target_type: file
-                          display_field: false
-                          display_default: false
-                        module: image
+                          target_type: media
+                        module: core
                         locked: false
                         cardinality: 1
                         translatable: true
@@ -6466,13 +8475,14 @@ items:
                   dependencies:
                     config:
                       - block_content.type.uiowa_banner
+                      - entity_browser.browser.media_browser
                       - field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt
                       - field.field.block_content.uiowa_banner.field_uiowa_banner_image
                       - field.field.block_content.uiowa_banner.field_uiowa_banner_link
                       - field.field.block_content.uiowa_banner.field_uiowa_banner_title
                     module:
+                      - entity_browser
                       - link
-                      - media_library
                   id: block_content.uiowa_banner.default
                   targetEntityType: block_content
                   bundle: uiowa_banner
@@ -6535,13 +8545,14 @@ items:
                   dependencies:
                     config:
                       - block_content.type.uiowa_card
+                      - entity_browser.browser.media_browser
                       - field.field.block_content.uiowa_card.field_uiowa_card_excerpt
                       - field.field.block_content.uiowa_card.field_uiowa_card_image
                       - field.field.block_content.uiowa_card.field_uiowa_card_link
                       - field.field.block_content.uiowa_card.field_uiowa_card_title
                     module:
+                      - entity_browser
                       - link
-                      - media_library
                   id: block_content.uiowa_card.default
                   targetEntityType: block_content
                   bundle: uiowa_card
@@ -6604,13 +8615,14 @@ items:
                   dependencies:
                     config:
                       - block_content.type.uiowa_feature
+                      - entity_browser.browser.media_browser
                       - field.field.block_content.uiowa_feature.field_uiowa_feature_image
                       - field.field.block_content.uiowa_feature.field_uiowa_feature_link
                       - field.field.block_content.uiowa_feature.field_uiowa_feature_sub
                       - field.field.block_content.uiowa_feature.field_uiowa_feature_title
                     module:
+                      - entity_browser
                       - link
-                      - media_library
                   id: block_content.uiowa_feature.default
                   targetEntityType: block_content
                   bundle: uiowa_feature
@@ -6673,14 +8685,15 @@ items:
                   dependencies:
                     config:
                       - block_content.type.uiowa_noteworthy
+                      - entity_browser.browser.media_browser
                       - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_excerpt
                       - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_image
                       - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_link
                       - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_sub
                       - field.field.block_content.uiowa_noteworthy.field_uiowa_noteworthy_title
                     module:
+                      - entity_browser
                       - link
-                      - media_library
                   id: block_content.uiowa_noteworthy.default
                   targetEntityType: block_content
                   bundle: uiowa_noteworthy
@@ -6785,11 +8798,12 @@ items:
                   dependencies:
                     config:
                       - block_content.type.uiowa_statistic
+                      - entity_browser.browser.media_browser
                       - field.field.block_content.uiowa_statistic.field_uiowa_statistic_excerpt
                       - field.field.block_content.uiowa_statistic.field_uiowa_statistic_image
                       - field.field.block_content.uiowa_statistic.field_uiowa_statistic_title
                     module:
-                      - media_library
+                      - entity_browser
                   id: block_content.uiowa_statistic.default
                   targetEntityType: block_content
                   bundle: uiowa_statistic
@@ -12099,6 +14113,96 @@ items:
       custom_storage: false
   -
     collection: ''
+    name: image.style.uiowa_lb_block_image_1200_x_800
+    data:
+      langcode: en
+      status: true
+      dependencies: {  }
+      name: uiowa_lb_block_image_1200_x_800
+      label: 'UIowa LB Block Image 1200 x 800'
+      effects:
+        6c872943-c078-48f4-8349-36c7d94623af:
+          uuid: 6c872943-c078-48f4-8349-36c7d94623af
+          id: image_scale_and_crop
+          weight: 1
+          data:
+            width: 1200
+            height: 800
+            anchor: center-center
+  -
+    collection: ''
+    name: image.style.uiowa_lb_block_image_2000_x_1300
+    data:
+      langcode: en
+      status: true
+      dependencies: {  }
+      name: uiowa_lb_block_image_2000_x_1300
+      label: 'UIowa LB Block Image 2000 x 1300'
+      effects:
+        c63e7875-a200-4a0f-842e-be0edca03217:
+          uuid: c63e7875-a200-4a0f-842e-be0edca03217
+          id: image_scale_and_crop
+          weight: 1
+          data:
+            width: 2000
+            height: 1300
+            anchor: center-center
+  -
+    collection: ''
+    name: image.style.uiowa_lb_block_image_560_x_373
+    data:
+      langcode: en
+      status: true
+      dependencies: {  }
+      name: uiowa_lb_block_image_560_x_373
+      label: 'UIowa LB Block Image 560 x 373'
+      effects:
+        6a7719a2-926b-49c6-9a88-5d5ab72df55e:
+          uuid: 6a7719a2-926b-49c6-9a88-5d5ab72df55e
+          id: image_scale_and_crop
+          weight: 1
+          data:
+            width: 560
+            height: 373
+            anchor: center-center
+  -
+    collection: ''
+    name: image.style.uiowa_lb_block_image_760_x_507
+    data:
+      langcode: en
+      status: true
+      dependencies: {  }
+      name: uiowa_lb_block_image_760_x_507
+      label: 'UIowa LB Block Image 760 x 507'
+      effects:
+        3d331900-2d60-4b19-a355-f7876d19ae9d:
+          uuid: 3d331900-2d60-4b19-a355-f7876d19ae9d
+          id: image_scale_and_crop
+          weight: 1
+          data:
+            width: 760
+            height: 507
+            anchor: center-center
+  -
+    collection: ''
+    name: image.style.uiowa_lb_block_image_990_x_660
+    data:
+      langcode: en
+      status: true
+      dependencies: {  }
+      name: uiowa_lb_block_image_990_x_660
+      label: 'UIowa LB Block Image 990 x 660'
+      effects:
+        57443511-1e0f-48ac-9cd8-df5e84b2d1c3:
+          uuid: 57443511-1e0f-48ac-9cd8-df5e84b2d1c3
+          id: image_scale_and_crop
+          weight: 1
+          data:
+            width: 990
+            height: 660
+            anchor: center-center
+  -
+    collection: ''
     name: layout_builder_styles.settings
     data:
       multiselect: single
@@ -12221,3 +14325,48 @@ items:
       type: section
       group: margin
       block_restrictions: {  }
+  -
+    collection: ''
+    name: responsive_image.styles.uiowa_lb_blocks
+    data:
+      langcode: en
+      status: true
+      dependencies:
+        config:
+          - image.style.uiowa_lb_block_image_1200_x_800
+          - image.style.uiowa_lb_block_image_2000_x_1300
+          - image.style.uiowa_lb_block_image_560_x_373
+          - image.style.uiowa_lb_block_image_760_x_507
+          - image.style.uiowa_lb_block_image_990_x_660
+        theme:
+          - collegiate_theme
+      id: uiowa_lb_blocks
+      label: 'UIowa LB Blocks'
+      image_style_mappings:
+        -
+          breakpoint_id: collegiate_theme.extra_large
+          multiplier: 1x
+          image_mapping_type: image_style
+          image_mapping: uiowa_lb_block_image_2000_x_1300
+        -
+          breakpoint_id: collegiate_theme.large
+          multiplier: 1x
+          image_mapping_type: image_style
+          image_mapping: uiowa_lb_block_image_1200_x_800
+        -
+          breakpoint_id: collegiate_theme.medium
+          multiplier: 1x
+          image_mapping_type: image_style
+          image_mapping: uiowa_lb_block_image_990_x_660
+        -
+          breakpoint_id: collegiate_theme.small
+          multiplier: 1x
+          image_mapping_type: image_style
+          image_mapping: uiowa_lb_block_image_760_x_507
+        -
+          breakpoint_id: collegiate_theme.extra_small
+          multiplier: 1x
+          image_mapping_type: image_style
+          image_mapping: uiowa_lb_block_image_560_x_373
+      breakpoint_group: collegiate_theme
+      fallback_image_style: uiowa_lb_block_image_560_x_373

--- a/docroot/modules/custom/uiowa_lb_blocks/config/optional/responsive_image.styles.uiowa_lb_blocks.yml
+++ b/docroot/modules/custom/uiowa_lb_blocks/config/optional/responsive_image.styles.uiowa_lb_blocks.yml
@@ -5,37 +5,36 @@ dependencies:
     - image.style.uiowa_lb_block_image_1200_x_800
     - image.style.uiowa_lb_block_image_2000_x_1300
     - image.style.uiowa_lb_block_image_560_x_373
-    - image.style.uiowa_lb_block_image_760_x_507
     - image.style.uiowa_lb_block_image_990_x_660
-  theme:
-    - collegiate_theme
+  module:
+    - uiowa_lb_blocks
 id: uiowa_lb_blocks
 label: 'UIowa LB Blocks'
 image_style_mappings:
   -
-    breakpoint_id: collegiate_theme.extra_large
+    breakpoint_id: uiowa_lb_blocks.extra_large
     multiplier: 1x
     image_mapping_type: image_style
     image_mapping: uiowa_lb_block_image_2000_x_1300
   -
-    breakpoint_id: collegiate_theme.large
+    breakpoint_id: uiowa_lb_blocks.large
     multiplier: 1x
     image_mapping_type: image_style
     image_mapping: uiowa_lb_block_image_1200_x_800
   -
-    breakpoint_id: collegiate_theme.medium
+    breakpoint_id: uiowa_lb_blocks.medium
     multiplier: 1x
     image_mapping_type: image_style
     image_mapping: uiowa_lb_block_image_990_x_660
   -
-    breakpoint_id: collegiate_theme.small
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: uiowa_lb_block_image_760_x_507
-  -
-    breakpoint_id: collegiate_theme.extra_small
+    breakpoint_id: uiowa_lb_blocks.small
     multiplier: 1x
     image_mapping_type: image_style
     image_mapping: uiowa_lb_block_image_560_x_373
-breakpoint_group: collegiate_theme
+  -
+    breakpoint_id: uiowa_lb_blocks.extra_small
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: uiowa_lb_block_image_560_x_373
+breakpoint_group: uiowa_lb_blocks
 fallback_image_style: uiowa_lb_block_image_560_x_373

--- a/docroot/modules/custom/uiowa_lb_blocks/uiowa_lb_blocks.breakpoints.yml
+++ b/docroot/modules/custom/uiowa_lb_blocks/uiowa_lb_blocks.breakpoints.yml
@@ -1,0 +1,30 @@
+uiowa_lb_blocks.extra_small:
+  label: mobile
+  mediaQuery: ''
+  weight: 0
+  multipliers:
+    - 1x
+uiowa_lb_blocks.small:
+  label: mobile
+  mediaQuery: 'all and (min-width: 576px) and (max-width: 767px)'
+  weight: 1
+  multipliers:
+    - 1x
+uiowa_lb_blocks.medium:
+  label: narrow
+  mediaQuery: 'all and (min-width: 768px) and (max-width: 991px)'
+  weight: 2
+  multipliers:
+    - 1x
+uiowa_lb_blocks.large:
+  label: wide
+  mediaQuery: 'all and (min-width: 992px) and (max-width: 1199px)'
+  weight: 3
+  multipliers:
+    - 1x
+uiowa_lb_blocks.extra_large:
+  label: wide
+  mediaQuery: 'all and (min-width: 1200px)'
+  weight: 4
+  multipliers:
+    - 1x

--- a/docroot/themes/custom/collegiate_theme/.gitignore
+++ b/docroot/themes/custom/collegiate_theme/.gitignore
@@ -8,4 +8,3 @@ hds/gulpfile.js
 hds/docs
 hds/dist
 hds/_preview.twig
-hds/assets/js

--- a/docroot/themes/custom/collegiate_theme/README.md
+++ b/docroot/themes/custom/collegiate_theme/README.md
@@ -1,4 +1,1 @@
-## Guidelines
-- **Twig Component Templates** should be generic and not make style assumptions. Avoid utility and stylized classes. See style variations for more information.
-- **Style variations** should implement a BEM style class `card--variation` at the top level of the component and leverages css to target and control styles. For example `.card--variation > .card-header: @extend text-muted;`.
-
+## Collegiate Theme

--- a/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bg-images/bg-images.css
+++ b/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bg-images/bg-images.css
@@ -1,0 +1,3 @@
+[data-responsive-background-image]{background-repeat:no-repeat;background-size:cover;background-position:center}[data-responsive-background-image] img{display:none}
+
+/*# sourceMappingURL=bg-images.css.map */

--- a/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bg-images/bg-images.css
+++ b/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bg-images/bg-images.css
@@ -1,3 +1,3 @@
-[data-responsive-background-image]{background-repeat:no-repeat;background-size:cover;background-position:center}[data-responsive-background-image] img{display:none}
+[data-responsive-background-image]{background-repeat:no-repeat;background-size:cover;background-position:center}[data-responsive-background-image] img{display:none}.no-js [data-responsive-background-image] img{display:block}
 
 /*# sourceMappingURL=bg-images.css.map */

--- a/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bold-headline 2/bold-headline.css
+++ b/docroot/themes/custom/collegiate_theme/assets/css/components/elements/bold-headline 2/bold-headline.css
@@ -1,0 +1,3 @@
+blockquote{font-weight:500;border-left:2px solid #FFCD00;padding:1.875rem;padding-top:1.25rem;padding-bottom:1.875rem;padding-left:1.875rem}
+
+/*# sourceMappingURL=bold-headline.css.map */

--- a/docroot/themes/custom/collegiate_theme/assets/js/collegiate_theme.js
+++ b/docroot/themes/custom/collegiate_theme/assets/js/collegiate_theme.js
@@ -3,19 +3,5 @@
  * Collegiate Subtheme behaviors.
  */
 
-(function ($, Drupal) {
 
-  'use strict';
-
-  /**
-   * Behavior description.
-   */
-  Drupal.behaviors.collegiate_theme = {
-    attach: function (context, settings) {
-
-      console.log('It works!');
-
-    }
-  };
-
-} (jQuery, Drupal));
+document.documentElement.className = document.documentElement.className.replace("no-js", "js");

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
@@ -1,6 +1,6 @@
 global-styling:
   js:
-    assets/js/collegiate-theme-base.js: {}
+    assets/js/collegiate_theme.js: {}
   css:
     base:
       assets/css/global.css: {}

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
@@ -71,6 +71,12 @@ mega-menu:
   css:
     component:
       assets/css/components/global/menus/mega-menu/mega-menu.css: { preprocess: false }
+responsive-bg:
+  css:
+    component:
+      assets/css/components/elements/bg-images/bg-images.css: { preprocess: false }
+  js:
+    hds/components/01 - elements/bg-images/bg-images.js: { preprocess: false }
 admin:
   css:
     component:

--- a/docroot/themes/custom/collegiate_theme/hds/assets/scss/_utilities.scss
+++ b/docroot/themes/custom/collegiate_theme/hds/assets/scss/_utilities.scss
@@ -152,6 +152,19 @@
 }
 
 
+//////////  Responsive BG Image
+
+@mixin responsive-bg {
+  [data-responsive-background-image] {
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center
+  }
+  [data-responsive-background-image] img {
+       display: none;
+  }
+}
+
 
 // Extends ///////////////
 %shadow {

--- a/docroot/themes/custom/collegiate_theme/hds/assets/scss/_utilities.scss
+++ b/docroot/themes/custom/collegiate_theme/hds/assets/scss/_utilities.scss
@@ -162,6 +162,9 @@
   }
   [data-responsive-background-image] img {
        display: none;
+       .no-js & {
+         display: block;
+       }
   }
 }
 

--- a/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/_bg-images.scss
+++ b/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/_bg-images.scss
@@ -1,0 +1,1 @@
+@include responsive-bg;

--- a/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/bg-images.js
+++ b/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/bg-images.js
@@ -1,0 +1,33 @@
+(() => {
+  class ResponsiveBackgroundImage {
+    constructor(element) {
+      this.element = element;
+      this.img = element.querySelector('img');
+      this.src = '';
+
+      this.img.addEventListener('load', () => {
+        this.update();
+      });
+
+      if (this.img.complete) {
+        this.update();
+      }
+    }
+
+    update() {
+      const src = typeof this.img.currentSrc !== 'undefined' ? this.img.currentSrc : this.img.src;
+
+      if (this.src !== src) {
+        this.src = src;
+        this.element.style.backgroundImage = `url("${this.src}")`;
+      }
+    }
+  }
+
+  const elements = document.querySelectorAll('[data-responsive-background-image]');
+  const backgroundImages = [];
+
+  for (let i = 0; i < elements.length; i++) {
+    backgroundImages.push(new ResponsiveBackgroundImage(elements[i]));
+  }
+})();

--- a/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/bg-images.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/01 - elements/bg-images/bg-images.twig
@@ -1,0 +1,8 @@
+<div style="min-height:600px;width:100%;" data-responsive-background-image="true">
+  <picture>
+    <source srcset="../../images/large.jpg" media="(min-width: 1220px)">
+    <source srcset="../../images/medium.jpg" media="(min-width: 740px)">
+    <source srcset="../../images/small.jpg" media="(min-width: 0px)">
+    <img src="../../images/small.jpg" alt="Alt Text" title="">
+  </picture>
+</div>

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/_banner-block.scss
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/_banner-block.scss
@@ -52,3 +52,4 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%23ffffff' fill-opacity='0.79' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
   }
 }
+

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/_banner-block.scss
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/_banner-block.scss
@@ -37,7 +37,6 @@
       width: 40%;
       @include padding($top: 0, $left: 0);
     }
-
   }
 
   &:before {

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/banner-block.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/banner-block/banner-block.twig
@@ -1,5 +1,11 @@
-<div class="banner" {% if banner_bg_image %} style="background-image: url('{% spaceless %}{{ banner_bg_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
-  <img class="banner__image" src="{{ banner_image }}"/>
+{% block banner_bg %}
+  {% if banner_bg_image %}
+    <div class="banner" {% if banner_bg_image %} style="background-image: url('{% spaceless %}{{ banner_bg_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+    {% endif %}
+  {% endblock %}
+  {% if banner_image %}
+    <img class="banner__image" src="{{ banner_image }}"/>
+  {% endif %}
   <div class="banner__container">
     {% if banner_title is not empty %}
       <h3 class="banner__title">{{ banner_title }}</h3>

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/feature-block/feature-block--basic.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/feature-block/feature-block--basic.twig
@@ -1,17 +1,20 @@
-<a href="{{ feature_link }}" tabindex="0" aria-expanded="{{ firstitem }}" class="feature feature__{{ counter }}" {% if feature_banner_image %}
- style="background-image: url('{% spaceless %}{{ feature_banner_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
-  <div class="feature__wrapper">
-    <div class="feature__content">
-      <div class="feature__bracket">
-        <h2 class="feature__heading">{{ feature_title }}</h2>
-        <hr class="feature__hr">
-        <p class="feature__subheading">{{ feature_sub }}</p>
-      </div>
-    </div>
-    <div class="feature__teaser">
-      <h3 class="feature__teaser-heading">{{ feature_title }}
-        <i aria-hidden="true" class="fas fa-plus"></i>
-      </h3>
+{% block feature_bg %}
+  {% if feature_banner_image %}
+    <a href="{{ feature_link }}" tabindex="0" aria-expanded="{{ firstitem }}" class="feature feature__{{ counter }}" {% if feature_banner_image %} style="background-image: url('{% spaceless %}{{ feature_banner_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+  {% endif %}
+{% endblock %}
+<div class="feature__wrapper">
+  <div class="feature__content">
+    <div class="feature__bracket">
+      <h2 class="feature__heading">{{ feature_title }}</h2>
+      <hr class="feature__hr">
+      <p class="feature__subheading">{{ feature_sub }}</p>
     </div>
   </div>
+  <div class="feature__teaser">
+    <h3 class="feature__teaser-heading">{{ feature_title }}
+      <i aria-hidden="true" class="fas fa-plus"></i>
+    </h3>
+  </div>
+</div>
 </a>

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/stat-block/stat-block--basic.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/stat-block/stat-block--basic.twig
@@ -1,6 +1,8 @@
-<div class="stat" {% if stat_image %}
-  style="background-image: url('{% spaceless %}{{ stat_image }}{% endspaceless %}'); background-size: cover; background-position: center"
-  {% endif %}>
-  <h2 class="stat__title">{{ stat_title }}</h2>
-  <p class="stat__description">{{ stat_summary }}</p>
+{% block stat_bg %}
+    {% if stat_image %}
+        <div class="stat" {% if stat_image %} style="background-image: url('{% spaceless %}{{ stat_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+        {% endif %}
+    {% endblock %}
+    <h2 class="stat__title">{{ stat_title }}</h2>
+    <p class="stat__description">{{ stat_summary }}</p>
 </div>

--- a/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/stat-block/stat-block--basic.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/02 - blocks/stat-block/stat-block--basic.twig
@@ -1,8 +1,8 @@
 {% block stat_bg %}
-    {% if stat_image %}
-        <div class="stat" {% if stat_image %} style="background-image: url('{% spaceless %}{{ stat_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
-        {% endif %}
-    {% endblock %}
-    <h2 class="stat__title">{{ stat_title }}</h2>
-    <p class="stat__description">{{ stat_summary }}</p>
+  {% if stat_image %}
+    <div class="stat" {% if stat_image %} style="background-image: url('{% spaceless %}{{ stat_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+    {% endif %}
+  {% endblock %}
+  <h2 class="stat__title">{{ stat_title }}</h2>
+  <p class="stat__description">{{ stat_summary }}</p>
 </div>

--- a/docroot/themes/custom/collegiate_theme/hds/components/_preview.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/_preview.twig
@@ -28,6 +28,7 @@
 <script src="./../../js/supposition.js"></script>
 <script src="./../../js/supersubs.js"></script>
 <script src="./../../js/superfish.js"></script>
+<script src="./../../js/responsiveBg.js"></script>
 
 <script type='text/javascript' src="../raw/uiowa-search/uiowa-search.js"></script>
 <script type='text/javascript' src="../raw/uiowa-links/uiowa-links.js"></script>

--- a/docroot/themes/custom/collegiate_theme/hds/components/_preview.twig
+++ b/docroot/themes/custom/collegiate_theme/hds/components/_preview.twig
@@ -28,8 +28,8 @@
 <script src="./../../js/supposition.js"></script>
 <script src="./../../js/supersubs.js"></script>
 <script src="./../../js/superfish.js"></script>
-<script src="./../../js/responsiveBg.js"></script>
 
+<script type='text/javascript' src="../raw/bg-images/bg-images.js"></script>
 <script type='text/javascript' src="../raw/uiowa-search/uiowa-search.js"></script>
 <script type='text/javascript' src="../raw/uiowa-links/uiowa-links.js"></script>
 <script type='text/javascript' src="../raw/uiowa-links-b/uiowa-links-b.js"></script>

--- a/docroot/themes/custom/collegiate_theme/scss/components/elements/bg-images/bg-images.scss
+++ b/docroot/themes/custom/collegiate_theme/scss/components/elements/bg-images/bg-images.scss
@@ -1,3 +1,3 @@
 @import "assets/scss/_variables.scss";
 @import "assets/scss/_utilities.scss";
-@import "components/02 - blocks/banner-block/_banner-block.scss";
+@import "components/01 - elements/bg-images/_bg-images.scss";

--- a/docroot/themes/custom/collegiate_theme/scss/global.scss
+++ b/docroot/themes/custom/collegiate_theme/scss/global.scss
@@ -69,4 +69,3 @@
 .toolbar-menu {
   font-size: unset;
 }
-

--- a/docroot/themes/custom/collegiate_theme/scss/global.scss
+++ b/docroot/themes/custom/collegiate_theme/scss/global.scss
@@ -70,4 +70,3 @@
   font-size: unset;
 }
 
-

--- a/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-banner.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-banner.html.twig
@@ -48,19 +48,24 @@ https://www.drupal.org/node/2367463
     {{ title_prefix }}
     {{ title_suffix }}
     {% embed "@banner/banner-block.twig" with {
-      "banner_bg_image": drupal_image(content.field_uiowa_banner_image[0]['#media'].image.entity.uri.value, 'uiowa_lb_blocks',  { class: 'card__img', alt: content.field_uiowa_card_image[0]['#media'].image.alt }, responsive=true),
+      "banner_bg_preview_image": file_url(content.field_uiowa_banner_image[0]['#media'].image.entity.uri.value | image_style('medium')),
+      "banner_bg_image": drupal_image(content.field_uiowa_banner_image[0]['#media'].image.entity.uri.value, 'uiowa_lb_blocks',  { class: 'card__img', alt: content.field_banner_card_image[0]['#media'].image.alt }, responsive=true),
       "banner_title": content.field_uiowa_banner_title,
       "banner_summary": content.field_uiowa_banner_excerpt,
       "banner_link_url": content.field_uiowa_banner_link[0]['#url'],
       "banner_link_title": content.field_uiowa_banner_link[0]['#title'],
     } %}
       {% block banner_bg %}
-        <div class="banner" data-responsive-background-image="true">
-          {{ banner_bg_image }}
-        {% endblock %}
-      {% endembed %}
+        {% if attributes.hasClass('js-layout-builder-block') %}
+          <div class="banner" {% if banner_bg_preview_image %} style="background-image: url('{% spaceless %}{{ banner_bg_preview_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+          {% else %}
+            <div class="banner" data-responsive-background-image="true">
+              {{ banner_bg_image }}
+            {% endif %}
+          {% endblock %}
+        {% endembed %}
+      {% endblock %}
 
-    {% endblock %}
-    {% if attributes.hasClass('js-layout-builder-block') %}
-    </div>
-  {% endif %}
+  {% if attributes.hasClass('js-layout-builder-block') %}
+  </div>
+{% endif %}

--- a/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-banner.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-banner.html.twig
@@ -44,16 +44,23 @@ https://www.drupal.org/node/2367463
 
   {% block content %}
     {{ attach_library('collegiate_theme/banner') }}
+    {{ attach_library('collegiate_theme/responsive-bg') }}
     {{ title_prefix }}
     {{ title_suffix }}
-    {% include "@banner/banner-block.twig" with {
-      "banner_bg_image": file_url(content.field_uiowa_banner_image[0]['#media'].image.entity.uri.value | image_style('medium')),
+    {% embed "@banner/banner-block.twig" with {
+      "banner_bg_image": drupal_image(content.field_uiowa_banner_image[0]['#media'].image.entity.uri.value, 'uiowa_lb_blocks',  { class: 'card__img', alt: content.field_uiowa_card_image[0]['#media'].image.alt }, responsive=true),
       "banner_title": content.field_uiowa_banner_title,
       "banner_summary": content.field_uiowa_banner_excerpt,
       "banner_link_url": content.field_uiowa_banner_link[0]['#url'],
       "banner_link_title": content.field_uiowa_banner_link[0]['#title'],
     } %}
-  {% endblock %}
-  {% if attributes.hasClass('js-layout-builder-block') %}
-  </div>
-{% endif %}
+      {% block banner_bg %}
+        <div class="banner" data-responsive-background-image="true">
+          {{ banner_bg_image }}
+        {% endblock %}
+      {% endembed %}
+
+    {% endblock %}
+    {% if attributes.hasClass('js-layout-builder-block') %}
+    </div>
+  {% endif %}

--- a/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-feature.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-feature.html.twig
@@ -43,12 +43,22 @@ set classes = [
     {{ title_prefix }}
     {{ title_suffix }}
     {{ attach_library('collegiate_theme/feature-block') }}
-    {% include "@feature-block/feature-block--basic.twig" with {
-			"feature_banner_image": file_url(content.field_uiowa_feature_image[0]['#media'].image.entity.uri.value | image_style('medium')),
-			"feature_title": content.field_uiowa_feature_title,
+    {% embed "@feature-block/feature-block--basic.twig" with {
+      "feature_banner_preview_image": file_url(content.field_uiowa_feature_image[0]['#media'].image.entity.uri.value | image_style('medium')),
+      "feature_banner_image": drupal_image(content.field_uiowa_feature_image[0]['#media'].image.entity.uri.value, 'uiowa_lb_blocks',  { class: 'card__img', alt: content.field_uiowa_feature_image[0]['#media'].image.alt }, responsive=true),
+      "feature_title": content.field_uiowa_feature_title,
 			"feature_sub": content.field_uiowa_feature_sub,
 			"feature_link": content.field_uiowa_feature_link[0]['#url'],
     } %}
+      {% block feature_bg %}
+        {% if attributes.hasClass('js-layout-builder-block') %}
+          <a href="{{ feature_link }}" tabindex="0" aria-expanded="{{ firstitem }}" class="feature feature__{{ counter }}" {% if feature_banner_preview_image %} style="background-image: url('{% spaceless %}{{ feature_banner_preview_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+      {% else %}
+          <a href="{{ feature_link }}" tabindex="0" aria-expanded="{{ firstitem }}" class="feature feature__{{ counter }}" data-responsive-background-image="true">
+            {{ feature_banner_image }}
+        {% endif %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% if attributes.hasClass('js-layout-builder-block') %}

--- a/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-statistic.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/block/block--inline-block--uiowa-statistic.html.twig
@@ -41,16 +41,29 @@ https://www.drupal.org/node/2367463
 {% if attributes.hasClass('js-layout-builder-block') %}
   <div{{ attributes.addclass(classes) }}>
   {% endif %}
-  {% block content %}
-    {{ attach_library('collegiate_theme/stat-block') }}
-    {{ title_prefix }}
-    {{ title_suffix }}
-    {% include "@stat-block/stat-block--basic.twig" with {
-      "stat_image": file_url(content.field_uiowa_statistic_image[0]['#media'].image.entity.uri.value | image_style('medium')),
-      "stat_title": content.field_uiowa_statistic_title,
-      "stat_summary": content.field_uiowa_statistic_excerpt,
-    } %}
-  {% endblock %}
+
+{% block content %}
+  {{ attach_library('collegiate_theme/stat-block') }}
+  {{ attach_library('collegiate_theme/responsive-bg') }}
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% embed "@stat-block/stat-block--basic.twig" with {
+    "stat_preview_image": file_url(content.field_uiowa_statistic_image[0]['#media'].image.entity.uri.value | image_style('medium')),
+    "stat_image": drupal_image(content.field_uiowa_statistic_image[0]['#media'].image.entity.uri.value, 'uiowa_lb_blocks',  { class: 'card__img', alt: content.field_uiowa_statistic_image[0]['#media'].image.alt }, responsive=true),
+    "stat_title": content.field_uiowa_statistic_title,
+    "stat_summary": content.field_uiowa_statistic_excerpt,
+  } %}
+    {% block stat_bg %}
+      {% if attributes.hasClass('js-layout-builder-block') %}
+        <div class="stat" {% if stat_preview_image %} style="background-image: url('{% spaceless %}{{ stat_preview_image }}{% endspaceless %}'); background-size: cover; background-position: center" {% endif %}>
+        {% else %}
+          <div class="stat" data-responsive-background-image="true">
+            {{ stat_image }}
+          {% endif %}
+        {% endblock %}
+      {% endembed %}
+    {% endblock %}
+
   {% if attributes.hasClass('js-layout-builder-block') %}
   </div>
 {% endif %}

--- a/docroot/themes/custom/collegiate_theme/templates/layout/html.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/layout/html.html.twig
@@ -32,7 +32,7 @@
   ]
 %}
 <!DOCTYPE html>
-<html{{ html_attributes }}>
+<html{{ html_attributes.addclass('no-js') }}>
   <head>
     <head-placeholder token="{{ placeholder_token }}">
     <title>{{ head_title|safe_join(' | ') }}</title>


### PR DESCRIPTION
- Added separate breakpoints for uiowa_lb_blocks: uiowa_lb_blocks.breakpoints.yml
- Block templates in collegiate_theme templates/block updated to use responsive images for inline and background images
- Using https://uiowa.github.io/hds/components/detail/bg-images.html add https://github.com/uiowa/uiowa01/blob/feature_uiowa_lb_blocks_enhancements/docroot/themes/custom/collegiate_theme/hds/components/01%20-%20elements/bg-images/bg-images.js for responsive background images