### PR TITLE
Feature: $layout_builder_enabled variable in html.html.twig

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/src/LayoutBuilderHelper.php
+++ b/docroot/modules/custom/layout_builder_custom/src/LayoutBuilderHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\layout_builder_custom;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\layout_builder\LayoutEntityHelperTrait;
+
+/**
+ * A helper class for accessing some layout builder information.
+ */
+class LayoutBuilderHelper {
+
+  use LayoutEntityHelperTrait;
+
+  /**
+   * Checks if layout builder is enabled for an entity.
+   */
+  public function layoutBuilderEnabled(EntityInterface $entity) {
+    return $this->isLayoutCompatibleEntity($entity);
+  }
+
+}

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -31,7 +31,7 @@ function collegiate_theme_preprocess_html(&$variables) {
   $variables['layout_builder_enabled'] = FALSE;
 
   $node = \Drupal::routeMatch()->getParameter('node');
-  if($node) {
+  if ($node) {
     // @todo Is there a better way to have a soft dependency on a class?
     if (class_exists('\Drupal\layout_builder_custom\LayoutBuilderHelper')) {
       $variables['layout_builder_enabled'] = \Drupal::classResolver('\Drupal\layout_builder_custom\LayoutBuilderHelper')->layoutBuilderEnabled($node);

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -31,6 +31,7 @@ function collegiate_theme_preprocess_html(&$variables) {
   $variables['layout_builder_enabled'] = FALSE;
 
   $node = \Drupal::routeMatch()->getParameter('node');
+
   if ($node) {
     // @todo Is there a better way to have a soft dependency on a class?
     if (class_exists('\Drupal\layout_builder_custom\LayoutBuilderHelper')) {

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -26,6 +26,17 @@ function collegiate_theme_preprocess_html(&$variables) {
   else {
     $variables['attributes']['class'][] = Html::cleanCssIdentifier('layout-page-sidebars-none');
   }
+
+  // Set a variable for whether layout builder is enabled.
+  $variables['layout_builder_enabled'] = FALSE;
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if($node) {
+    // @todo Is there a better way to have a soft dependency on a class?
+    if (class_exists('\Drupal\layout_builder_custom\LayoutBuilderHelper')) {
+      $variables['layout_builder_enabled'] = \Drupal::classResolver('\Drupal\layout_builder_custom\LayoutBuilderHelper')->layoutBuilderEnabled($node);
+    }
+  }
 }
 
 /**

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -53,7 +53,7 @@ function collegiate_theme_preprocess_page(&$variables) {
   $variables['collegiate_theme_container_settings'] = theme_get_setting('collegiate_theme_container_settings');
 
   // Set a variable for whether layout builder is enabled.
-  $variables['layout_builder_enabled'] = false;
+  $variables['layout_builder_enabled'] = FALSE;
   if (!empty($variables['node'])) {
     /** @var \Drupal\node\NodeInterface $node */
     $node = $variables['node'];

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -51,6 +51,18 @@ function collegiate_theme_preprocess_page(&$variables) {
   $variables['collegiate_theme_header_alignment_settings'] = theme_get_setting('collegiate_theme_header_alignment_settings');
   $variables['collegiate_theme_header_color_settings'] = theme_get_setting('collegiate_theme_header_color_settings');
   $variables['collegiate_theme_container_settings'] = theme_get_setting('collegiate_theme_container_settings');
+
+  // Set a variable for whether layout builder is enabled.
+  $variables['layout_builder_enabled'] = false;
+  if (!empty($variables['node'])) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $variables['node'];
+
+    // @todo Is there a better way to have a soft dependency on a class?
+    if (class_exists('\Drupal\layout_builder_custom\LayoutBuilderHelper')) {
+      $variables['layout_builder_enabled'] = \Drupal::classResolver('\Drupal\layout_builder_custom\LayoutBuilderHelper')->layoutBuilderEnabled($node);
+    }
+  }
 }
 
 /**

--- a/docroot/themes/custom/collegiate_theme/templates/layout/html.html.twig
+++ b/docroot/themes/custom/collegiate_theme/templates/layout/html.html.twig
@@ -29,6 +29,7 @@
     not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
     node_type ? 'page-node-type-' ~ node_type|clean_class,
     db_offline ? 'db-offline',
+    layout_builder_enabled ? 'layout-builder-enabled' : 'layout-builder-disabled',
   ]
 %}
 <!DOCTYPE html>


### PR DESCRIPTION
Added LayoutBuilderHelper class to access a protected method from the LayoutEntityHelperTrait. Added logic to collegiate_theme_preprocess_html to expose a variable  in the html.html.twig template. Added body class in html.html.twig based on the variable value.

# Testing
1. `drush @theming.local si collegiate_basic`
2. Add basic page content item
3. Visit page and inspect the HTML. There should be a 'layout-builder-enabled' body class.
4. Enable another content type such as Seminar
5. Add a content item of the content type you just enabled
6. Visit the newly added page and inspect the HTML. There should be a 'layout-builder-disabled' body class.