### PR TITLE
Feature: LB inline block editing updates

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -11,36 +11,40 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_form_alter().
  */
 function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  $form_ids = ['layout_builder_update_block', 'layout_builder_add_block'];
+
+  // Only continue if this is one of the above forms.
+  if (!in_array($form_id, $form_ids)) {
+    return;
+  }
+
+  // Always set title field to not be required.
+  $form['settings']['label']['#required'] = FALSE;
+
   if ($form_id == 'layout_builder_add_block') {
-    $form['settings']['label']['#required'] = FALSE;
+    // Set the display of the label to FALSE when adding a block.
     $form['settings']['label_display']['#default_value'] = FALSE;
+  }
 
-    $label = $form['settings']['label'];
-    $label_display = $form['settings']['label_display'];
+  $label = $form['settings']['label'];
+  $label_display = $form['settings']['label_display'];
 
-    unset($form['settings']['label']);
-    unset($form['settings']['label_display']);
+  unset($form['settings']['label']);
+  unset($form['settings']['label_display']);
 
-    $label += [
-      '#attributes' => ['name' => 'inline_block_label'],
-      '#states' => [
-        'visible' => [
-          ':input[name="inline_block_label_display"]' => [
-            'checked' => TRUE,
-          ],
+  $label += [
+    '#states' => [
+      'visible' => [
+        ':input[name="settings[label_display]"]' => [
+          'checked' => TRUE,
         ],
       ],
-    ];
+    ],
+  ];
 
-    $label_display += [
-      '#attributes' => [
-        'name' => 'inline_block_label_display',
-      ],
-    ];
-
-    $form['settings'] += [
-      'label_display' => $label_display,
-      'label' => $label,
-    ];
-  }
+  $form['settings'] += [
+    'label_display' => $label_display,
+    'label' => $label,
+  ];
 }


### PR DESCRIPTION
# Testing Instructions
1. `git checkout feature_inline_block_edit_updates`
2. `composer install`
3. `drush @theming.local si collegiate_basic`
4. Check that toggling the "Display title" checkbox shows/hides the "Title" field on both adding and editing blocks via layout builder
5. Check that title can be left off when adding, then added when updating
6. Check that title can be used when adding, then removed when updating
7. Check that title field is never required
8. Check that "Display title" checkbox and "Title" field display at the end of the form when adding and editing blocks