### PR TITLE
Feature: Collegiate search/settings

### DIFF
--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.libraries.yml
@@ -21,6 +21,7 @@ global-styling:
       assets/css/components/elements/table/table.css: {}
       assets/css/components/elements/tabs/tabs.css: {}
       assets/css/components/elements/video/video.css: {}
+      assets/css/components/elements/search/search.css: {}
       assets/css/components/global/branding/branding.css: {}
       assets/css/components/global/header/header.css: {}
       assets/css/components/global/footer/footer.css: {}

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -90,4 +90,16 @@ function collegiate_theme_form_alter(&$form, $form_state, $form_id) {
   if (strpos($form_id, 'uiowa_bar_search_form') !== FALSE) {
     $form['#attributes']['class'][] = 'hds-content hds-content__search';
   }
+  if (strpos($form_id, 'search_block_form') !== FALSE) {
+    $form['#attributes']['class'][] = 'hds-content hds-search';
+  }
+}
+
+
+function collegiate_theme_form_views_exposed_form_alter(&$form, $form_state, $form_id) {
+  $view_ids = ['book_toc', 'book_search'];
+  $view = $form_state->getStorage('view');
+  if ($form_id == 'views_exposed_form' && in_array($view['view']->id(), $view_ids)) {
+    $form['#attributes']['class'][] = 'hds-content hds-search';
+  }
 }

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -93,9 +93,6 @@ function collegiate_theme_form_alter(&$form, $form_state, $form_id) {
   if (strpos($form_id, 'search_block_form') !== FALSE) {
     $form['#attributes']['class'][] = 'hds-content hds-search';
   }
-  if (strpos($form_id, 'search_form') !== FALSE) {
-    $form['#attributes']['class'][] = 'hds-content hds-search';
-  }
 }
 
 

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -93,6 +93,9 @@ function collegiate_theme_form_alter(&$form, $form_state, $form_id) {
   if (strpos($form_id, 'search_block_form') !== FALSE) {
     $form['#attributes']['class'][] = 'hds-content hds-search';
   }
+  if (strpos($form_id, 'search_form') !== FALSE) {
+    $form['#attributes']['class'][] = 'hds-content hds-search';
+  }
 }
 
 

--- a/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
+++ b/docroot/themes/custom/collegiate_theme/collegiate_theme.theme
@@ -80,6 +80,16 @@ function collegiate_theme_preprocess_block(&$variables) {
 }
 
 /**
+ *
+ */
+function collegiate_theme_preprocess_form(&$variables) {
+  // Add class to your specific form
+  if ($variables['attributes']['id'] == 'search-block-form') {
+    $variables['attributes']['class'][] = 'hds-content hds-search ';
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function collegiate_theme_form_alter(&$form, $form_state, $form_id) {
@@ -89,9 +99,6 @@ function collegiate_theme_form_alter(&$form, $form_state, $form_id) {
   }
   if (strpos($form_id, 'uiowa_bar_search_form') !== FALSE) {
     $form['#attributes']['class'][] = 'hds-content hds-content__search';
-  }
-  if (strpos($form_id, 'search_block_form') !== FALSE) {
-    $form['#attributes']['class'][] = 'hds-content hds-search';
   }
 }
 

--- a/docroot/themes/custom/collegiate_theme/config/install/collegiate_theme.settings.yml
+++ b/docroot/themes/custom/collegiate_theme/config/install/collegiate_theme.settings.yml
@@ -1,3 +1,3 @@
-collegiate_theme_header_alignment_settings: site-header__default
+collegiate_theme_header_alignment_settings: site-header__left
 collegiate_theme_header_color_settings: site-header--secondary
 collegiate_theme_container_settings: page__container

--- a/docroot/themes/custom/collegiate_theme/scss/components/elements/search/search.scss
+++ b/docroot/themes/custom/collegiate_theme/scss/components/elements/search/search.scss
@@ -1,0 +1,14 @@
+@import "assets/scss/_variables.scss";
+@import "assets/scss/_utilities.scss";
+@import "components/01 - elements/search/_search.scss";
+
+// full width for any elements not part of the form
+
+.hds-search .search-help-link {
+  width: 100%;
+}
+
+.container-inline .hds-search div,
+.container-inline .hds-search label {
+  display: flex;
+}

--- a/docroot/themes/custom/collegiate_theme/scss/global.scss
+++ b/docroot/themes/custom/collegiate_theme/scss/global.scss
@@ -9,7 +9,8 @@
 .layout__container {
   .block-system-breadcrumb-block,
   .block-field-blocknodepagetitle,
-  .block-field-blocknodepagebody {
+  .block-field-blocknodepagebody,
+  .block-views {
     flex-basis: 100%;
   }
 }

--- a/docroot/themes/custom/collegiate_theme/theme-settings.php
+++ b/docroot/themes/custom/collegiate_theme/theme-settings.php
@@ -27,9 +27,7 @@ function collegiate_theme_form_system_theme_settings_alter(&$form, FormStateInte
     '#title' => t('Header Alignment'),
     '#description' => t('Select an option'),
     '#options' => [
-      'site-header__default' => t('Site name left, Nav right (default)'),
-      'site-header__center' => t('Site name center, Nav center'),
-      'site-header__left' => t('Site name left, Nav left'),
+      'site-header__left' => t('Site name left, Nav left (default)'),
     ],
     '#default_value' => theme_get_setting('collegiate_theme_header_alignment_settings'),
   ];

--- a/docroot/themes/custom/collegiate_theme/theme-settings.php
+++ b/docroot/themes/custom/collegiate_theme/theme-settings.php
@@ -27,7 +27,7 @@ function collegiate_theme_form_system_theme_settings_alter(&$form, FormStateInte
     '#title' => t('Header Alignment'),
     '#description' => t('Select an option'),
     '#options' => [
-      'site-header__left' => t('Site name left, Nav left (default)'),
+      'site-header__left' => t('Menu left (default)'),
     ],
     '#default_value' => theme_get_setting('collegiate_theme_header_alignment_settings'),
   ];


### PR DESCRIPTION
Work on issues #312 and #306.

# How to test

1. `drush @theming.local si collegiate`
2. Verify that site install has 'site name left, menu left' 
3. Enable uiowa_book module
4. Go to a-z list page and verify HDS styles are applied: https://theming.uiowa.local.site/a-z
5. Add views exposed search block to page with layout builder enabled and verify that styles are there
6. Let me know if you have any feedback on https://github.com/uiowa/uiowa01/pull/315#issuecomment-572709647

Also, we are going to need the patch listed on #217 if @mark-bennett-uiowa wants to place a search form within layout builder.